### PR TITLE
Added isomorphic command handlers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ resolvers += Resolver.sonatypeRepo("releases")
 
 addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.6.3")
 
-//wartremoverErrors ++= Warts.allBut(Wart.Any, Wart.Nothing, Wart.Throw, Wart.AsInstanceOf, Wart.NoNeedForMonad)
+wartremoverErrors ++= Warts.allBut(Wart.Any, Wart.Nothing, Wart.Throw, Wart.IsInstanceOf, Wart.AsInstanceOf, Wart.NoNeedForMonad)
 
 scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature",
                       "-Xlint", "-Ywarn-unused-import", "-Yno-adapted-args", "-Ywarn-dead-code",

--- a/build.sbt
+++ b/build.sbt
@@ -6,12 +6,13 @@ scalaVersion := "2.11.7"
 
 libraryDependencies += "org.spire-math" %% "cats" % "0.2.0"
 libraryDependencies += "com.lihaoyi" %% "pprint" % "0.3.6"
+libraryDependencies += "com.chuusai" %% "shapeless" % "2.2.5"
 
 resolvers += Resolver.sonatypeRepo("releases")
 
 addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.6.3")
 
-wartremoverErrors ++= Warts.allBut(Wart.Any, Wart.Nothing, Wart.Throw, Wart.AsInstanceOf, Wart.NoNeedForMonad)
+//wartremoverErrors ++= Warts.allBut(Wart.Any, Wart.Nothing, Wart.Throw, Wart.AsInstanceOf, Wart.NoNeedForMonad)
 
 scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature",
                       "-Xlint", "-Ywarn-unused-import", "-Yno-adapted-args", "-Ywarn-dead-code",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 logLevel := Level.Warn
 
 resolvers += Resolver.sonatypeRepo("releases")
-//addSbtPlugin("org.brianmckenna" % "sbt-wartremover" % "0.14")
+addSbtPlugin("org.brianmckenna" % "sbt-wartremover" % "0.14")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 logLevel := Level.Warn
 
 resolvers += Resolver.sonatypeRepo("releases")
-addSbtPlugin("org.brianmckenna" % "sbt-wartremover" % "0.14")
+//addSbtPlugin("org.brianmckenna" % "sbt-wartremover" % "0.14")

--- a/src/main/scala/Domain/Door.scala
+++ b/src/main/scala/Domain/Door.scala
@@ -27,7 +27,7 @@ object Door {
 
   def openDoorsLogic: Flow[Unit] =
     handler {
-      handler[Close.type, Closed.type] orElse
+      promote[Close.type, Closed.type] orElse
         { case _ => failCommand("Open door can only be closed.") }
     } >>
       waitForAndSwitch {
@@ -36,8 +36,8 @@ object Door {
 
   def closedDoorsLogic: Flow[Unit] =
     handler {
-      handler[Lock, Locked] orElse
-      handler[Open.type, Opened.type] orElse
+      promote[Lock, Locked] orElse
+      promote[Open.type, Opened.type] orElse
         { case _ => failCommand("Closed door can only be opened or locked.") }
     } >>
       waitForAndSwitch {
@@ -56,7 +56,7 @@ object Door {
       }
 
   val aggregateLogic: List[Flow[Unit]] = List(
-    handler { handler[Register, Registered] } >> waitFor { case Registered(_) => () },
+    handler { promote[Register, Registered] } >> waitFor { case Registered(_) => () },
     waitFor { case Registered(_) => () } >> openDoorsLogic
   )
 

--- a/src/main/scala/Domain/Door.scala
+++ b/src/main/scala/Domain/Door.scala
@@ -27,8 +27,8 @@ object Door {
 
   def openDoorsLogic: Flow[Unit] =
     handler {
-      case Close => emitEvent(Closed)
-      case _ => failCommand("Open door can only be closed.")
+      handler[Close.type, Closed.type] orElse
+        { case _ => failCommand("Open door can only be closed.") }
     } >>
       waitForAndSwitch {
         case Closed => closedDoorsLogic
@@ -36,9 +36,9 @@ object Door {
 
   def closedDoorsLogic: Flow[Unit] =
     handler {
-      case Lock(key) => emitEvent(Locked(key))
-      case Open => emitEvent(Opened)
-      case _ => failCommand("Closed door can only be opened or locked.")
+      handler[Lock, Locked] orElse
+      handler[Open.type, Opened.type] orElse
+        { case _ => failCommand("Closed door can only be opened or locked.") }
     } >>
       waitForAndSwitch {
         case Opened => openDoorsLogic
@@ -56,7 +56,7 @@ object Door {
       }
 
   val aggregateLogic: List[Flow[Unit]] = List(
-    handler { case Register(id) => emitEvent(Registered(id)) } >> waitFor { case Registered(_) => () },
+    handler { handler[Register, Registered] } >> waitFor { case Registered(_) => () },
     waitFor { case Registered(_) => () } >> openDoorsLogic
   )
 

--- a/src/main/scala/lib/CaseClassTransformer.scala
+++ b/src/main/scala/lib/CaseClassTransformer.scala
@@ -1,0 +1,24 @@
+package lib
+
+import shapeless.Generic
+
+/**
+  * Typeclass for transforming a case class to another case class with a different name.
+  * The types should should be isomorphic.
+  *
+  * @tparam I The input type which should be isomorphic to type O
+  * @tparam O The output type which should be isomorphic to type I
+  */
+@annotation.implicitNotFound("""Could not prove that ${I} can be converted to/from ${O}.""")
+trait CaseClassTransformer[I, O] {
+  def transform(cmd: I): O
+}
+
+object CaseClassTransformer {
+  @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.ExplicitImplicitTypes"))
+  implicit def transform[I, O, IRepr, ORepr](implicit genericC: Generic.Aux[I, IRepr],
+                                             genericE: Generic.Aux[O, ORepr],
+                                             proof: IRepr =:= ORepr): CaseClassTransformer[I, O] = new CaseClassTransformer[I, O] {
+    def transform(input: I): O = genericE.from(genericC.to(input))
+  }
+}


### PR DESCRIPTION
Since a lot of commands are isomorphic to their event (only the name of the type differs). I introduced isomorphic command handlers.

TODO's:
- [x] Restore wartremover (got this error: https://github.com/puffnfresh/wartremover/issues/188)
- [x] `safeCast` and `proofE` seems a bit meh, any smarter tricks for that matter?
